### PR TITLE
add $in filter!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/simple/maps.js
+++ b/simple/maps.js
@@ -38,6 +38,11 @@ exports.prefix = function (a, str) {
 exports.is = function (a, type) {
   return typeof a === type
 }
+
+exports.in = function (a, b) {
+  return ~b.indexOf(a)
+}
+
 exports.type = function (a) {
   return typeof a
 }

--- a/test/filter.js
+++ b/test/filter.js
@@ -16,6 +16,7 @@ var data = [
   {source: 'b', dest: 'a', rel: ['name', '@alice']},
   {source: 'b', dest: 'a', rel: ['contact', true, false]},
   {source: 'b', dest: 'a', rel: ['contact', false, null]},
+  {source: 'x', dest: 'a', rel: ['age', false, null]},
   true,
   false
 ]
@@ -30,7 +31,9 @@ var queries = [
   {rel: {$prefix: ['contact', true]}},
   {rel: ['contact', {$is: 'boolean'}]},
   {$is: 'boolean'},
-  {$is: 'string'}
+  {$is: 'string'},
+  {source: {$in: ['x', 'a']}},
+  {rel: [{$in: ['name', 'age']}]}
 ]
 
 var expected = [
@@ -49,7 +52,16 @@ var expected = [
     {source: 'b', dest: 'a', rel: ['contact', false, null]}
   ],
   [true, false],
-  ['string', 'strength']
+  ['string', 'strength'],
+  [
+    {source: 'a', dest: 'b', rel: ['name', '@bob']},
+    {source: 'x', dest: 'a', rel: ['age', false, null]},
+  ],
+  [
+    {source: 'a', dest: 'b', rel: ['name', '@bob']},
+    {source: 'b', dest: 'a', rel: ['name', '@alice']},
+    {source: 'x', dest: 'a', rel: ['age', false, null]},
+  ]
 ]
 
 tape('okay: true', function (t) {


### PR DESCRIPTION
**Semver change** : patch/ minor

**Problem**: I'm needing to do some "join" type queries using ssb-query, for example "get me all posts from my friends that happened in the last month".
I want to be able to do a query which says something like : 

```js
const opts = {
  query: [{
    $filter: {
      value: {
        author: { $in: ['@mikey', '@dominc', '@piet'] }
      }
    }
  }]
}
sbot.query.read(opts, cb)
```
I want this filtering to happen on the server side.

I'm imagining this is going to be needed in a lot of cases coming up.

**Solution**
I wrote a test! then tried to read the code, which I didn't completely grok (i'm at art hack, it's late), but then I remembered _I don't need to understand it_. I channeled _Dominic Tarr reading Java_, squinted at the code then added a function which made the test pass!